### PR TITLE
Changes to EventHandler for Exiled ScpsInfoDisplay.

### DIFF
--- a/ScpsInfoDisplay/Config.cs
+++ b/ScpsInfoDisplay/Config.cs
@@ -13,12 +13,12 @@ namespace ScpsInfoDisplay
         [Description("Display strings. Format: Role, display string.")]
         public Dictionary<RoleTypeId, string> DisplayStrings { get; set; } = new Dictionary<RoleTypeId, string>()
         {
-            { RoleTypeId.Scp049, "<color=#FF0000>SCP-049 [%healthpercent%% Zombies: %zombies%] </color>" },
-            { RoleTypeId.Scp079, "<color=#FF00000>SCP-079 [%generators%%engaging%/3] Lvl: %079level% Exp: %079experience% Energy: %079energy%</color>" },
-            { RoleTypeId.Scp096, "<color=#FF0000>SCP-096 [%healthpercent%%] </color>" },
-            { RoleTypeId.Scp106, "<color=#FF0000>SCP-106 [%healthpercent%%] Vigor: %106vigor%% </color>" },
-            { RoleTypeId.Scp173, "<color=#FF0000>SCP-173 [%healthpercent%%] </color>" },
-            { RoleTypeId.Scp939, "<color=#FF0000>SCP-939 [%healthpercent%%] </color>" },
+            { RoleTypeId.Scp049, "<color=#FF0000><size=30>SCP-049</color> [<color=#19FF40>%healthpercent%%</color>]\n<color=#19B2FF>Zombies: %zombies%</color></size>" },
+            { RoleTypeId.Scp079, "<color=#FF0000><size=30>SCP-079</color> <color=#19FF40>Generators:</color> [<color=#19FF40>%generators%</color><color=#FF0000>%engaging%</color><color=#19FF40>/3</color>]\n <color=#19B2FF>Level: %079level%</color> <color=#FF19FF>Energy: %079energy%</color></size>" },
+            { RoleTypeId.Scp096, "<color=#FF0000><size=30>SCP-096</color> [<color=#19FF40>%healthpercent%%</color>] </size>" },
+            { RoleTypeId.Scp106, "<color=#FF0000><size=30>SCP-106</color> [<color=#19FF40>%healthpercent%%</color>] <color=#19B2FF>Vigor: %106vigor%% </size></color>" },
+            { RoleTypeId.Scp173, "<color=#FF0000><size=30>SCP-173</color> [<color=#19FF40>%healthpercent%%</color>] </size>" },
+            { RoleTypeId.Scp939, "<color=#FF0000><size=30>SCP-939</color> [<color=#19FF40>%healthpercent%%</color>] </size>" },
         };
         [Description("Custom roles integrations. Format: SessionVariable that marks that the player belongs to that role, display string.")]
         public Dictionary<string, string> CustomRolesIntegrations { get; set; } = new Dictionary<string, string>();
@@ -27,7 +27,7 @@ namespace ScpsInfoDisplay
         [Description("Display text position offset.")]
         public sbyte TextPositionOffset { get; set; } = 30;
         [Description("The player seeing the list will be highlighted with the special marker to the left. Leave it empty if disabled.")]
-        public string PlayersMarker { get; set; } = "<color=#D7E607>You:</color>";
+        public string PlayersMarker { get; set; } = "<color=#D7E607><size=30>You: </size></color>";
         [Description("Display debug messages in server console?")]
         public bool Debug { get; set; } = false;
     }

--- a/ScpsInfoDisplay/Config.cs
+++ b/ScpsInfoDisplay/Config.cs
@@ -13,12 +13,12 @@ namespace ScpsInfoDisplay
         [Description("Display strings. Format: Role, display string.")]
         public Dictionary<RoleTypeId, string> DisplayStrings { get; set; } = new Dictionary<RoleTypeId, string>()
         {
-            { RoleTypeId.Scp049, "<color=#D51D1D>SCP-049 [%healthpercent%% Zombies: %zombies%] %distance%</color>" },
-            { RoleTypeId.Scp079, "<color=#D51D1D>SCP-079 [%generators%%engaging%/3] Lvl: %079level% Exp: %079experience% Energy: %079energy%</color>" },
-            { RoleTypeId.Scp096, "<color=#D51D1D>SCP-096 [%healthpercent%%] %distance%</color>" },
-            { RoleTypeId.Scp106, "<color=#D51D1D>SCP-106 [%healthpercent%%] Vigor: %106vigor%% %distance%</color>" },
-            { RoleTypeId.Scp173, "<color=#D51D1D>SCP-173 [%healthpercent%%] %distance%</color>" },
-            { RoleTypeId.Scp939, "<color=#D51D1D>SCP-939 [%healthpercent%%] %distance%</color>" },
+            { RoleTypeId.Scp049, "<color=#FF0000>SCP-049 [%healthpercent%% Zombies: %zombies%] </color>" },
+            { RoleTypeId.Scp079, "<color=#FF00000>SCP-079 [%generators%%engaging%/3] Lvl: %079level% Exp: %079experience% Energy: %079energy%</color>" },
+            { RoleTypeId.Scp096, "<color=#FF0000>SCP-096 [%healthpercent%%] </color>" },
+            { RoleTypeId.Scp106, "<color=#FF0000>SCP-106 [%healthpercent%%] Vigor: %106vigor%% </color>" },
+            { RoleTypeId.Scp173, "<color=#FF0000>SCP-173 [%healthpercent%%] </color>" },
+            { RoleTypeId.Scp939, "<color=#FF0000>SCP-939 [%healthpercent%%] </color>" },
         };
         [Description("Custom roles integrations. Format: SessionVariable that marks that the player belongs to that role, display string.")]
         public Dictionary<string, string> CustomRolesIntegrations { get; set; } = new Dictionary<string, string>();
@@ -27,7 +27,7 @@ namespace ScpsInfoDisplay
         [Description("Display text position offset.")]
         public sbyte TextPositionOffset { get; set; } = 30;
         [Description("The player seeing the list will be highlighted with the special marker to the left. Leave it empty if disabled.")]
-        public string PlayersMarker { get; set; } = "<color=#D51D1D>You --></color>";
+        public string PlayersMarker { get; set; } = "<color=#D7E607>You:</color>";
         [Description("Display debug messages in server console?")]
         public bool Debug { get; set; } = false;
     }

--- a/ScpsInfoDisplay/EventHandlers.cs
+++ b/ScpsInfoDisplay/EventHandlers.cs
@@ -56,7 +56,7 @@ namespace ScpsInfoDisplay
         }
 
         private string ProcessStringVariables(string raw, Player observer, Player target) => raw
-            .Replace("%arhealth%", target.ArtificialHealth > 0 ? target.ArtificialHealth.ToString() : "")
+            .Replace("%arhealth%", Math.Floor(target.HumeShield) >= 0 ? Math.Floor(target.HumeShield).ToString() : "")
             .Replace("%healthpercent%", Math.Floor(target.Health / target.MaxHealth * 100).ToString())
             .Replace("%health%", Math.Floor(target.Health).ToString())
             .Replace("%generators%", Generator.List.Count(gen => gen.IsEngaged).ToString())

--- a/ScpsInfoDisplay/ScpsInfoDisplay.cs
+++ b/ScpsInfoDisplay/ScpsInfoDisplay.cs
@@ -8,9 +8,9 @@ namespace ScpsInfoDisplay
     {
         public override string Prefix => "scpsinfodisplay";
         public override string Name => "ScpsInfoDisplay";
-        public override string Author => "bladuk.";
+        public override string Author => "Vicious Vikki";
         public override Version Version { get; } = new Version(2, 0, 1);
-        public override Version RequiredExiledVersion { get; } = new Version(6, 0, 0);
+        public override Version RequiredExiledVersion { get; } = new Version(8, 1, 0);
         public static ScpsInfoDisplay Singleton = new ScpsInfoDisplay();
         private EventHandlers _eventHandlers;
 

--- a/ScpsInfoDisplay/ScpsInfoDisplay.csproj
+++ b/ScpsInfoDisplay/ScpsInfoDisplay.csproj
@@ -32,12 +32,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\..\..\Downloads\Master Exiled\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>$(EXILED_REFERENCES)\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\Downloads\Master Exiled\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(EXILED_REFERENCES)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="EXILED">
-      <Version>8.0.1</Version>
+      <Version>8.2.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/ScpsInfoDisplay/ScpsInfoDisplay.csproj
+++ b/ScpsInfoDisplay/ScpsInfoDisplay.csproj
@@ -31,25 +31,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\Steam\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
-    <Reference Include="Exiled.API">
-      <HintPath>..\..\Exiled.API.dll</HintPath>
-    </Reference>
-    <Reference Include="Exiled.Events">
-      <HintPath>..\..\Exiled.Events.dll</HintPath>
-    </Reference>
-    <Reference Include="NorthwoodLib">
-      <HintPath>..\..\..\nwapi_plugins\NorthwoodLib.dll</HintPath>
+      <HintPath>..\..\..\..\Downloads\Master Exiled\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\..\..\Downloads\Master Exiled\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -58,6 +46,11 @@
     <Compile Include="EventHandlers.cs" />
     <Compile Include="ScpsInfoDisplay.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="EXILED">
+      <Version>8.0.1</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Please note the majority of these changes are purely cosmetic, which is why I want to bring your attention to EventHandler.cs

You had 
.Replace("%arhealth%", target.ArtificialHealth > 0 ? target.ArtificialHealth.ToString() : "")
which was detecting the Artificial Health of SCPs, using Exiled, SCPs doesnt have ArtificialHealth, it has Humeshield.

The change is this.
.Replace("%arhealth%", Math.Floor(target.HumeShield) >= 0 ? Math.Floor(target.HumeShield).ToString() : "")
This will display the Humeshield if the config has %arhealth% and it will not vanish when it is depleted